### PR TITLE
Migrate to Python 3

### DIFF
--- a/Packagecloud.py
+++ b/Packagecloud.py
@@ -12,7 +12,7 @@
    https://packagecloud.io/docs/api
 """
 
-from __future__ import print_function
+
 import shutil
 import sys
 import time

--- a/copypackages
+++ b/copypackages
@@ -1,8 +1,8 @@
-#!/usr/bin/env python -u
+#!/usr/bin/env python
 """Copy Packages from one repo to another"""
-from __future__ import print_function
+
 import argparse
-import ConfigParser
+import configparser
 import shutil
 import tempfile
 
@@ -36,7 +36,7 @@ def configure():
                         help='Print debug output')
     args = parser.parse_args()
 
-    config = ConfigParser.SafeConfigParser()
+    config = configparser.SafeConfigParser()
     config.read(args.config)
 
     token = config.get('packagecloud', 'token')
@@ -101,7 +101,7 @@ def main():
                      conf['destrepo']), end='')
 
         if conf['interactive']:
-            copy = raw_input("(y/N)? ").lower() == 'y'
+            copy = input("(y/N)? ").lower() == 'y'
         else:
             copy = True
 

--- a/downloadpackages
+++ b/downloadpackages
@@ -1,8 +1,8 @@
-#!/usr/bin/env python -u
+#!/usr/bin/env python
 """Download Packages"""
-from __future__ import print_function
+
 import argparse
-import ConfigParser
+import configparser
 
 from Packagecloud import download_package
 from Packagecloud import get_all_packages
@@ -32,7 +32,7 @@ def configure():
                         help='Print debug output')
     args = parser.parse_args()
 
-    config = ConfigParser.SafeConfigParser()
+    config = configparser.SafeConfigParser()
     config.read(args.config)
 
     token = config.get('packagecloud', 'token')
@@ -90,7 +90,7 @@ def main():
             package['filename'], conf['repouser'], conf['srcrepo']))
 
         if conf['interactive']:
-            dwnl = raw_input("Download this package (y/N)? ").lower() == 'y'
+            dwnl = input("Download this package (y/N)? ").lower() == 'y'
 
         if dwnl:
             downloadresult = download_package(package, '.', conf)

--- a/listpackages
+++ b/listpackages
@@ -1,8 +1,8 @@
-#!/usr/bin/env python -u
+#!/usr/bin/env python
 """List Packages"""
-from __future__ import print_function
+
 import argparse
-import ConfigParser
+import configparser
 
 from Packagecloud import get_all_packages
 from Packagecloud import show_packagelist
@@ -33,7 +33,7 @@ def configure():
                         help='Print debug output')
     args = parser.parse_args()
 
-    config = ConfigParser.SafeConfigParser()
+    config = configparser.SafeConfigParser()
     config.read(args.config)
 
     token = config.get('packagecloud', 'token')

--- a/promotepackages
+++ b/promotepackages
@@ -1,8 +1,8 @@
-#!/usr/bin/env python -u
+#!/usr/bin/env python
 """Promote Packages"""
-from __future__ import print_function
+
 import argparse
-import ConfigParser
+import configparser
 
 from Packagecloud import get_all_packages
 from Packagecloud import promote_package
@@ -33,7 +33,7 @@ def configure():
                         help='Print debug output')
     args = parser.parse_args()
 
-    config = ConfigParser.SafeConfigParser()
+    config = configparser.SafeConfigParser()
     config.read(args.config)
 
     token = config.get('packagecloud', 'token')
@@ -87,7 +87,7 @@ def main():
                      conf['repouser'], conf['destrepo']), end='')
 
         if conf['interactive']:
-            promote = raw_input("Promote this package (y/N)? ").lower() == 'y'
+            promote = input("Promote this package (y/N)? ").lower() == 'y'
         else:
             promote = True
 

--- a/yankpackages
+++ b/yankpackages
@@ -1,8 +1,8 @@
-#!/usr/bin/env python -u
+#!/usr/bin/env python
 """Destroy Packages"""
-from __future__ import print_function
+
 import argparse
-import ConfigParser
+import configparser
 
 from Packagecloud import abort
 from Packagecloud import destroy_package
@@ -35,7 +35,7 @@ def configure():
                         help='Print debug output')
     args = parser.parse_args()
 
-    config = ConfigParser.SafeConfigParser()
+    config = configparser.SafeConfigParser()
     config.read(args.config)
 
     token = config.get('packagecloud', 'token')
@@ -76,7 +76,7 @@ def main():
                          conf['match'], conf['type'])
 
     if not conf['interactive'] and not conf['force']:
-        yankall = raw_input("Are you sure you want to yank all (y/N)? "). \
+        yankall = input("Are you sure you want to yank all (y/N)? "). \
             lower() == 'y'
         if not yankall:
             abort('Aborted', 1)
@@ -101,7 +101,7 @@ def main():
             package['filename'], conf['repouser'], conf['srcrepo']), end='')
 
         if conf['interactive']:
-            yank = raw_input("Yank this package (y/N)? ").lower() == 'y'
+            yank = input("Yank this package (y/N)? ").lower() == 'y'
 
         if yank:
             yankresult = destroy_package(package, conf)


### PR DESCRIPTION
python-packagecloud does not current run under Python 3. This PR makes the requisite changes to ensure that it does.